### PR TITLE
Implement desktop notifications and configuration for notification display names

### DIFF
--- a/readme/todo.md
+++ b/readme/todo.md
@@ -36,9 +36,11 @@ The following features are grouped by **Importance** (Foundation, Critical, High
      <strong>Description</strong>: Updating the local and remote "last read" state to clear unread notification badges.<br/>
      <strong>Implementation</strong>: Hitting the <code>/ack</code> endpoint for channels when viewed.
     </details>
-3. **Proper Push Notifications** *(Difficulty: Medium) (🔒 Blocked by WebSockets)*
-   - **Description**: Replace the current hacky workaround for notifications with reliable, instant desktop push notifications for new messages.
-   - **Implementation**: Listen for `MESSAGE_CREATE` events in real-time over the WebSocket Gateway to trigger native notifications correctly without missing any or double-notifying.
+3. <details>
+      <summary><sub><s><strong>Proper Push Notifications</strong> <em>(Difficulty: Medium) (🔒 Blocked by WebSockets)</em></s></sub></summary>
+      <strong>Description</strong>: Replace the current hacky workaround for notifications with reliable, instant desktop push notifications for new messages.<br/>
+      <strong>Implementation</strong>: Listen for `MESSAGE_CREATE` events in real-time over the WebSocket Gateway to trigger native notifications correctly without missing any or double-notifying.
+    </details>
 4. <details>
      <summary><sub><s><strong>Message Editing</strong> <em>(Difficulty: Medium)</em></s></sub></summary>
      <strong>Description</strong>: Ability to edit existing sent messages.<br/>

--- a/src/api/message.rs
+++ b/src/api/message.rs
@@ -12,6 +12,7 @@ pub struct Message {
     pub content: Option<String>,
     pub timestamp: String,
     pub mentions: Vec<User>,
+    pub guild_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,8 @@ pub struct Config {
     pub discreet_notifs: bool,
     #[serde(default)]
     pub silent_typing: bool,
+    #[serde(default)]
+    pub notifs_display_username: bool,
     pub display_username: bool,
     pub emoji_map: Vec<(String, String)>,
 }
@@ -36,6 +38,7 @@ impl Default for Config {
             vim_mode: true,
             discreet_notifs: false,
             silent_typing: false,
+            notifs_display_username: false,
             display_username: false,
             emoji_map: Vec::new(),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,7 @@ pub struct App {
     silent_typing: bool,
     is_loading: bool,
     pub active_notifications: HashMap<String, Vec<notify_rust::NotificationHandle>>,
+    pub notifs_display_username: bool,
     display_username: bool,
     logs: Vec<String>,
 }
@@ -176,6 +177,7 @@ pub struct Setup {
     vim_mode: bool,
     vim_state: Option<VimState>,
     discreet_notifs: bool,
+    notifs_display_username: bool,
     silent_typing: bool,
     display_username: bool,
 }
@@ -222,6 +224,7 @@ impl Default for App {
             silent_typing: false,
             is_loading: false,
             active_notifications: HashMap::new(),
+            notifs_display_username: false,
             display_username: false,
             logs: Vec::new(),
         }
@@ -237,6 +240,7 @@ impl App {
             vim_mode,
             vim_state,
             discreet_notifs,
+            notifs_display_username,
             silent_typing,
             display_username,
         ) = (
@@ -246,6 +250,7 @@ impl App {
             values.vim_mode,
             values.vim_state,
             values.discreet_notifs,
+            values.notifs_display_username,
             values.silent_typing,
             values.display_username,
         );
@@ -292,6 +297,7 @@ impl App {
             silent_typing,
             is_loading: false,
             active_notifications: HashMap::new(),
+            notifs_display_username,
             display_username,
             logs: Vec::new(),
         }
@@ -326,6 +332,7 @@ async fn run_app(token: String, config: config::Config) -> Result<(), Error> {
         vim_mode,
         vim_state,
         discreet_notifs: config.discreet_notifs,
+        notifs_display_username: config.notifs_display_username,
         silent_typing: config.silent_typing,
         display_username: config.display_username,
     })));

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,7 @@ pub enum AppAction {
     EndLoadingMessages,
     SelectEmoji,
     Paste(String),
+    DesktopNotification(String, String, String),
     Tick,
 }
 

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -1320,7 +1320,7 @@ pub async fn handle_keys_events(
                 let is_mentioned = state
                     .current_user
                     .as_ref()
-                    .map_or(false, |u| msg.mentions.iter().any(|m| m.id == u.id));
+                    .is_some_and(|u| msg.mentions.iter().any(|m| m.id == u.id));
 
                 if is_dm || is_mentioned {
                     let is_self = state

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -1366,13 +1366,12 @@ pub async fn handle_keys_events(
                                     cached_channel_name = Some(channel.name.clone());
                                     break;
                                 }
-                                if let Some(children) = &channel.children {
-                                    if let Some(child) =
+                                if let Some(children) = &channel.children
+                                    && let Some(child) =
                                         children.iter().find(|c| c.id == msg.channel_id)
-                                    {
-                                        cached_channel_name = Some(child.name.clone());
-                                        break;
-                                    }
+                                {
+                                    cached_channel_name = Some(child.name.clone());
+                                    break;
                                 }
                             }
                         }

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -1332,12 +1332,15 @@ pub async fn handle_keys_events(
                         let sender = if state.notifs_display_username {
                             msg.author.username.clone()
                         } else {
-                            msg.author.global_name.clone().unwrap_or_else(|| msg.author.username.clone())
+                            msg.author
+                                .global_name
+                                .clone()
+                                .unwrap_or_else(|| msg.author.username.clone())
                         };
                         let is_dm_clone = is_dm;
                         let msg_clone = msg.clone();
                         let discreet = state.discreet_notifs;
-                        
+
                         let guild_clone = state.selected_guild.as_ref().and_then(|sg| {
                             if msg.guild_id.as_deref() == Some(sg.id.as_str()) {
                                 Some(sg.clone())
@@ -1347,12 +1350,16 @@ pub async fn handle_keys_events(
                         });
 
                         let guild_name = msg.guild_id.as_ref().and_then(|gid| {
-                            state.guilds.iter().find(|g| &g.id == gid).map(|g| g.name.clone())
+                            state
+                                .guilds
+                                .iter()
+                                .find(|g| &g.id == gid)
+                                .map(|g| g.name.clone())
                         });
 
                         let api_client = state.api_client.clone();
                         let tx = tx_action.clone();
-                        
+
                         tokio::spawn(async move {
                             let (summary, body) = if discreet {
                                 let body = if is_dm_clone {
@@ -1362,22 +1369,26 @@ pub async fn handle_keys_events(
                                 };
                                 (sender, body)
                             } else {
-                                let body = if msg_clone.content.as_ref().is_some_and(|c| !c.is_empty()) {
-                                    msg_clone.map_mentions(guild_clone)
-                                } else {
-                                    "Sent an attachment".to_string()
-                                };
+                                let body =
+                                    if msg_clone.content.as_ref().is_some_and(|c| !c.is_empty()) {
+                                        msg_clone.map_mentions(guild_clone)
+                                    } else {
+                                        "Sent an attachment".to_string()
+                                    };
                                 let mut final_sender = sender.clone();
-                                
+
                                 if !is_dm_clone {
                                     let mut channel_name = String::new();
-                                    if let Ok(crate::api::AnyChannel::Guild(c)) = api_client.get_channel(&msg_clone.channel_id).await {
+                                    if let Ok(crate::api::AnyChannel::Guild(c)) =
+                                        api_client.get_channel(&msg_clone.channel_id).await
+                                    {
                                         channel_name = format!("#{}", c.name);
                                     }
-                                    
+
                                     if let Some(gn) = guild_name {
                                         if !channel_name.is_empty() {
-                                            final_sender = format!("{} in {} ({})", sender, gn, channel_name);
+                                            final_sender =
+                                                format!("{} in {} ({})", sender, gn, channel_name);
                                         } else {
                                             final_sender = format!("{} in {}", sender, gn);
                                         }
@@ -1385,11 +1396,17 @@ pub async fn handle_keys_events(
                                         final_sender = format!("{} in {}", sender, channel_name);
                                     }
                                 }
-                                
+
                                 (final_sender, body)
                             };
 
-                            let _ = tx.send(AppAction::DesktopNotification(summary, body, msg_clone.channel_id)).await;
+                            let _ = tx
+                                .send(AppAction::DesktopNotification(
+                                    summary,
+                                    body,
+                                    msg_clone.channel_id,
+                                ))
+                                .await;
                         });
                     }
 

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -1357,6 +1357,26 @@ pub async fn handle_keys_events(
                                 .map(|g| g.name.clone())
                         });
 
+                        let mut cached_channel_name = None;
+                        if msg.guild_id.is_some()
+                            && state.selected_guild.as_ref().map(|g| &g.id) == msg.guild_id.as_ref()
+                        {
+                            for channel in &state.channels {
+                                if channel.id == msg.channel_id {
+                                    cached_channel_name = Some(channel.name.clone());
+                                    break;
+                                }
+                                if let Some(children) = &channel.children {
+                                    if let Some(child) =
+                                        children.iter().find(|c| c.id == msg.channel_id)
+                                    {
+                                        cached_channel_name = Some(child.name.clone());
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
                         let api_client = state.api_client.clone();
                         let tx = tx_action.clone();
 
@@ -1379,7 +1399,9 @@ pub async fn handle_keys_events(
 
                                 if !is_dm_clone {
                                     let mut channel_name = String::new();
-                                    if let Ok(crate::api::AnyChannel::Guild(c)) =
+                                    if let Some(name) = cached_channel_name {
+                                        channel_name = format!("#{}", name);
+                                    } else if let Ok(crate::api::AnyChannel::Guild(c)) =
                                         api_client.get_channel(&msg_clone.channel_id).await
                                     {
                                         channel_name = format!("#{}", c.name);

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -1315,46 +1315,93 @@ pub async fn handle_keys_events(
                         .ack_message(&channel_id_clone, &msg_id_clone)
                         .await;
                 });
-            } else if state.dms.iter().any(|dm| dm.id == msg.channel_id) {
-                // If it's a DM and we're not actively viewing it, maybe notify
-                let is_self = state
+            } else {
+                let is_dm = state.dms.iter().any(|dm| dm.id == msg.channel_id);
+                let is_mentioned = state
                     .current_user
                     .as_ref()
-                    .is_some_and(|u| u.id == msg.author.id);
+                    .map_or(false, |u| msg.mentions.iter().any(|m| m.id == u.id));
 
-                if !is_self {
-                    let sender = msg.author.username.clone();
-                    let content = if state.discreet_notifs {
-                        "Sent you a DM".to_string()
-                    } else {
-                        msg.content
-                            .clone()
-                            .unwrap_or_else(|| "Sent an attachment".to_string())
-                    };
-                    if let Ok(handle) = notify_rust::Notification::new()
-                        .summary(&sender)
-                        .body(&content)
-                        .appname("vimcord")
-                        .show()
-                    {
+                if is_dm || is_mentioned {
+                    let is_self = state
+                        .current_user
+                        .as_ref()
+                        .is_some_and(|u| u.id == msg.author.id);
+
+                    if !is_self {
+                        let sender = msg.author.username.clone();
+                        let is_dm_clone = is_dm;
+                        let msg_clone = msg.clone();
+                        let discreet = state.discreet_notifs;
+                        
+                        let guild_clone = state.selected_guild.as_ref().and_then(|sg| {
+                            if msg.guild_id.as_deref() == Some(sg.id.as_str()) {
+                                Some(sg.clone())
+                            } else {
+                                None
+                            }
+                        });
+
+                        let guild_name = msg.guild_id.as_ref().and_then(|gid| {
+                            state.guilds.iter().find(|g| &g.id == gid).map(|g| g.name.clone())
+                        });
+
+                        let api_client = state.api_client.clone();
+                        let tx = tx_action.clone();
+                        
+                        tokio::spawn(async move {
+                            let (summary, body) = if discreet {
+                                let body = if is_dm_clone {
+                                    "Sent you a DM".to_string()
+                                } else {
+                                    "Mentioned you in a channel".to_string()
+                                };
+                                (sender, body)
+                            } else {
+                                let body = if msg_clone.content.as_ref().is_some_and(|c| !c.is_empty()) {
+                                    msg_clone.map_mentions(guild_clone)
+                                } else {
+                                    "Sent an attachment".to_string()
+                                };
+                                let mut final_sender = sender.clone();
+                                
+                                if !is_dm_clone {
+                                    let mut channel_name = String::new();
+                                    if let Ok(crate::api::AnyChannel::Guild(c)) = api_client.get_channel(&msg_clone.channel_id).await {
+                                        channel_name = format!("#{}", c.name);
+                                    }
+                                    
+                                    if let Some(gn) = guild_name {
+                                        if !channel_name.is_empty() {
+                                            final_sender = format!("{} in {} ({})", sender, gn, channel_name);
+                                        } else {
+                                            final_sender = format!("{} in {}", sender, gn);
+                                        }
+                                    } else if !channel_name.is_empty() {
+                                        final_sender = format!("{} in {}", sender, channel_name);
+                                    }
+                                }
+                                
+                                (final_sender, body)
+                            };
+
+                            let _ = tx.send(AppAction::DesktopNotification(summary, body, msg_clone.channel_id)).await;
+                        });
+                    }
+
+                    if is_dm {
+                        // Jump this DM to the top of the list
+                        if let Some(pos) = state.dms.iter().position(|dm| dm.id == msg.channel_id) {
+                            let mut dm = state.dms.remove(pos);
+                            dm.last_message_id = Some(msg.id.clone());
+                            state.dms.insert(0, dm);
+                        }
+
                         state
-                            .active_notifications
-                            .entry(msg.channel_id.clone())
-                            .or_default()
-                            .push(handle);
+                            .last_message_ids
+                            .insert(msg.channel_id.clone(), msg.id.clone());
                     }
                 }
-
-                // Jump this DM to the top of the list
-                if let Some(pos) = state.dms.iter().position(|dm| dm.id == msg.channel_id) {
-                    let mut dm = state.dms.remove(pos);
-                    dm.last_message_id = Some(msg.id.clone());
-                    state.dms.insert(0, dm);
-                }
-
-                state
-                    .last_message_ids
-                    .insert(msg.channel_id.clone(), msg.id.clone());
             }
 
             // Remove the typing indicator if the author sent a message in the channel
@@ -1579,6 +1626,20 @@ pub async fn handle_keys_events(
             state.status_message =
                 "Chatting in channel. Press Enter to send message, Esc to return to channels."
                     .to_string();
+        }
+        AppAction::DesktopNotification(summary, body, channel_id) => {
+            if let Ok(handle) = notify_rust::Notification::new()
+                .summary(&summary)
+                .body(&body)
+                .appname("vimcord")
+                .show()
+            {
+                state
+                    .active_notifications
+                    .entry(channel_id)
+                    .or_default()
+                    .push(handle);
+            }
         }
         AppAction::Tick => {
             state.tick_count = state.tick_count.wrapping_add(1);

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -1329,7 +1329,11 @@ pub async fn handle_keys_events(
                         .is_some_and(|u| u.id == msg.author.id);
 
                     if !is_self {
-                        let sender = msg.author.username.clone();
+                        let sender = if state.notifs_display_username {
+                            msg.author.username.clone()
+                        } else {
+                            msg.author.global_name.clone().unwrap_or_else(|| msg.author.username.clone())
+                        };
                         let is_dm_clone = is_dm;
                         let msg_clone = msg.clone();
                         let discreet = state.discreet_notifs;


### PR DESCRIPTION
This pull request introduces a new user-configurable option to display usernames in desktop notifications and significantly refactors the desktop notification logic to provide more contextually accurate and informative notifications. The changes span configuration, state management, and the notification dispatch pipeline.

**Desktop Notification Improvements:**

* Added a new configuration option `notifs_display_username` to control whether notifications display the username or the global name of the sender. This option is now threaded through config (`src/config.rs`), app state (`src/main.rs`), and setup. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR15-R16) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR41) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR168) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR180) [[5]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR227) [[6]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR243) [[7]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR253) [[8]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR300) [[9]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR335)
* Refactored notification logic to:
  - Distinguish between DMs and mentions, and provide tailored notification summaries and bodies.
  - Include guild and channel names in notification summaries for mentions in servers, improving context for the user.
  - Use a new `DesktopNotification` app action to standardize notification dispatching. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR114) [[2]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L1318-R1413) [[3]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7R1425-R1426) [[4]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7R1651-R1664)

**API and Data Model Updates:**

* Added an optional `guild_id` field to the `Message` struct to support associating messages with their guild, enabling richer notification context.

**Documentation:**

* Updated the todo list to clarify the status of proper push notifications, now visually indicating it is blocked and providing more detail in a collapsible section.