### PR TITLE
Add Visual mode with yank and paste functionality

### DIFF
--- a/file
+++ b/file
@@ -1,0 +1,2 @@
+line one
+line two

--- a/readme/keybinds.md
+++ b/readme/keybinds.md
@@ -36,10 +36,15 @@ When Vim mode is enabled, typing text is done in **Insert Mode** while navigatio
 | `k` | Move cursor up (or select previous message in chat) |
 | `w` | Move cursor forward to the next word |
 | `b` | Move cursor backward to the previous word |
-| `x` | Delete the character under the cursor |
+| `v` | Enter Visual mode for text selection |
+| `V` | Enter Visual Line mode for selecting entire lines |
+| `y` | Yank (copy) the current selection; `yy` yanks current line |
+| `p` / `P` | Paste the yanked text (after/before cursor, or line-wise) |
+| `x` | Delete the character under the cursor (or selection in Visual mode) |
 | `dw` | Delete the word in front of the cursor |
 | `db` | Delete the word before the cursor |
 | `dd` | Delete the current line (or delete the selected message if you authored it) |
+| `d` | Delete the selected text (in Visual mode) |
 | `gg` | Move cursor to the start of selection |
 | `G` | Move cursor to the end of input (or clear message selection) |
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,7 @@ pub enum InputMode {
     Command,
     Search,
     Visual,
+    VisualLine,
 }
 
 #[derive(Debug)]
@@ -531,7 +532,7 @@ async fn run_app(token: String, config: config::Config) -> Result<(), Error> {
                 execute!(io::stdout(), SetCursorStyle::BlinkingBar).ok();
             } else {
                 match state_guard.mode {
-                    InputMode::Normal | InputMode::Visual => {
+                    InputMode::Normal | InputMode::Visual | InputMode::VisualLine => {
                         execute!(io::stdout(), SetCursorStyle::BlinkingBlock).ok();
                     }
                     InputMode::Insert | InputMode::Command | InputMode::Search => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,7 @@ pub enum InputMode {
     Insert,
     Command,
     Search,
+    Visual,
 }
 
 #[derive(Debug)]
@@ -530,7 +531,7 @@ async fn run_app(token: String, config: config::Config) -> Result<(), Error> {
                 execute!(io::stdout(), SetCursorStyle::BlinkingBar).ok();
             } else {
                 match state_guard.mode {
-                    InputMode::Normal => {
+                    InputMode::Normal | InputMode::Visual => {
                         execute!(io::stdout(), SetCursorStyle::BlinkingBlock).ok();
                     }
                     InputMode::Insert | InputMode::Command | InputMode::Search => {

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -929,25 +929,32 @@ pub fn draw_ui(f: &mut ratatui::Frame, app: &mut App) {
             if let Some(visual_start) = vim_state.visual_start {
                 let mut start = visual_start.min(app.cursor_position);
                 let mut end = visual_start.max(app.cursor_position);
-                let end_len = app.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
+                let end_len = app.input[end..]
+                    .chars()
+                    .next()
+                    .map(|c| c.len_utf8())
+                    .unwrap_or(0);
                 end = (end + end_len).min(app.input.len());
-                
+
                 if app.mode == InputMode::VisualLine {
                     start = app.input[..start].rfind('\n').map(|i| i + 1).unwrap_or(0);
-                    end = app.input[end..].find('\n').map(|i| end + i + 1).unwrap_or(app.input.len());
+                    end = app.input[end..]
+                        .find('\n')
+                        .map(|i| end + i + 1)
+                        .unwrap_or(app.input.len());
                 }
-                
+
                 let mut lines = Vec::new();
                 let mut current_pos = 0;
-                
+
                 for line in app.input.split('\n') {
                     let line_start = current_pos;
                     let line_end = current_pos + line.len();
-                    
+
                     let mut spans = vec![];
                     let overlap_start = start.max(line_start);
                     let overlap_end = end.min(line_end);
-                    
+
                     if overlap_start < overlap_end {
                         if line_start < overlap_start {
                             spans.push(Span::raw(&app.input[line_start..overlap_start]));
@@ -962,7 +969,7 @@ pub fn draw_ui(f: &mut ratatui::Frame, app: &mut App) {
                     } else {
                         spans.push(Span::raw(&app.input[line_start..line_end]));
                     }
-                    
+
                     lines.push(Line::from(spans));
                     current_pos = line_end + 1;
                 }

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -924,13 +924,18 @@ pub fn draw_ui(f: &mut ratatui::Frame, app: &mut App) {
         _ => format!("Input: {}", display_status_message),
     };
 
-    let input_text = if let InputMode::Visual = app.mode {
+    let input_text = if app.mode == InputMode::Visual || app.mode == InputMode::VisualLine {
         if let Some(vim_state) = &app.vim_state {
             if let Some(visual_start) = vim_state.visual_start {
-                let start = visual_start.min(app.cursor_position);
-                let end = visual_start.max(app.cursor_position);
+                let mut start = visual_start.min(app.cursor_position);
+                let mut end = visual_start.max(app.cursor_position);
                 let end_len = app.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
-                let end = (end + end_len).min(app.input.len());
+                end = (end + end_len).min(app.input.len());
+                
+                if app.mode == InputMode::VisualLine {
+                    start = app.input[..start].rfind('\n').map(|i| i + 1).unwrap_or(0);
+                    end = app.input[end..].find('\n').map(|i| end + i + 1).unwrap_or(app.input.len());
+                }
                 
                 let mut lines = Vec::new();
                 let mut current_pos = 0;

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -924,8 +924,56 @@ pub fn draw_ui(f: &mut ratatui::Frame, app: &mut App) {
         _ => format!("Input: {}", display_status_message),
     };
 
+    let input_text = if let InputMode::Visual = app.mode {
+        if let Some(vim_state) = &app.vim_state {
+            if let Some(visual_start) = vim_state.visual_start {
+                let start = visual_start.min(app.cursor_position);
+                let end = visual_start.max(app.cursor_position);
+                let end_len = app.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
+                let end = (end + end_len).min(app.input.len());
+                
+                let mut lines = Vec::new();
+                let mut current_pos = 0;
+                
+                for line in app.input.split('\n') {
+                    let line_start = current_pos;
+                    let line_end = current_pos + line.len();
+                    
+                    let mut spans = vec![];
+                    let overlap_start = start.max(line_start);
+                    let overlap_end = end.min(line_end);
+                    
+                    if overlap_start < overlap_end {
+                        if line_start < overlap_start {
+                            spans.push(Span::raw(&app.input[line_start..overlap_start]));
+                        }
+                        spans.push(Span::styled(
+                            &app.input[overlap_start..overlap_end],
+                            Style::default().reversed(),
+                        ));
+                        if overlap_end < line_end {
+                            spans.push(Span::raw(&app.input[overlap_end..line_end]));
+                        }
+                    } else {
+                        spans.push(Span::raw(&app.input[line_start..line_end]));
+                    }
+                    
+                    lines.push(Line::from(spans));
+                    current_pos = line_end + 1;
+                }
+                Text::from(lines)
+            } else {
+                Text::from(app.input.as_str())
+            }
+        } else {
+            Text::from(app.input.as_str())
+        }
+    } else {
+        Text::from(app.input.as_str())
+    };
+
     f.render_widget(
-        Paragraph::new(app.input.as_str()).block(
+        Paragraph::new(input_text).block(
             Block::default()
                 .title(Span::styled(title, Style::default().fg(title_color)))
                 .borders(Borders::ALL)

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -822,7 +822,8 @@ pub async fn handle_keys_events(
             if state.vim_mode && (state.mode == InputMode::Insert
                 || state.mode == InputMode::Command
                 || state.mode == InputMode::Search
-                || state.mode == InputMode::Visual)
+                || state.mode == InputMode::Visual
+                || state.mode == InputMode::VisualLine)
             {
                 state.mode = InputMode::Normal;
                 if let Some(vim_state) = &mut state.vim_state {
@@ -952,7 +953,7 @@ pub async fn handle_keys_events(
                 handle_user_typing(&mut state);
             } else {
                 match state.mode {
-                    InputMode::Normal | InputMode::Visual => {
+                    InputMode::Normal | InputMode::Visual | InputMode::VisualLine => {
                         vim::handle_vim_keys(state, c, tx_action).await;
                     }
                     InputMode::Insert | InputMode::Command | InputMode::Search => {

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -819,11 +819,12 @@ pub async fn handle_keys_events(
         AppAction::InputEscape => {
             // In vim mode, Esc switches from Insert to Normal mode and returns early.
             // In non-vim mode (or vim Normal mode), Esc triggers navigation (handled below).
-            if state.vim_mode && (state.mode == InputMode::Insert
-                || state.mode == InputMode::Command
-                || state.mode == InputMode::Search
-                || state.mode == InputMode::Visual
-                || state.mode == InputMode::VisualLine)
+            if state.vim_mode
+                && (state.mode == InputMode::Insert
+                    || state.mode == InputMode::Command
+                    || state.mode == InputMode::Search
+                    || state.mode == InputMode::Visual
+                    || state.mode == InputMode::VisualLine)
             {
                 state.mode = InputMode::Normal;
                 if let Some(vim_state) = &mut state.vim_state {

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -77,41 +77,39 @@ pub async fn handle_input_events(
             _ = time::sleep(Duration::from_millis(10)) => {
                 if event::poll(Duration::from_millis(0))? {
                     match event::read()? {
-                        event::Event::Key(key) => {
-                            if key.kind == KeyEventKind::Press {
-                                if key.code == KeyCode::Char('c') && key.modifiers.contains(event::KeyModifiers::CONTROL) {
-                                    tx.send(AppAction::SigInt).await.ok();
-                                } else {
-                                    match key.code {
-                                        KeyCode::Esc => {
-                                            tx.send(AppAction::InputEscape).await.ok();
-                                        }
-                                        KeyCode::Enter => {
-                                            tx.send(AppAction::InputSubmit).await.ok();
-                                        }
-                                        KeyCode::Backspace => {
-                                            tx.send(AppAction::InputBackspace).await.ok();
-                                        }
-                                        KeyCode::Delete => {
-                                            tx.send(AppAction::InputDelete).await.ok();
-                                        }
-                                        KeyCode::Up => {
-                                            tx.send(AppAction::SelectPrevious).await.ok();
-                                        }
-                                        KeyCode::Down => {
-                                            tx.send(AppAction::SelectNext).await.ok();
-                                        }
-                                        KeyCode::Left => {
-                                            tx.send(AppAction::SelectLeft).await.ok();
-                                        }
-                                        KeyCode::Right => {
-                                            tx.send(AppAction::SelectRight).await.ok();
-                                        }
-                                        KeyCode::Char(c) => {
-                                            tx.send(AppAction::InputChar(c)).await.ok();
-                                        }
-                                        _ => {}
+                        event::Event::Key(key) if key.kind == KeyEventKind::Press => {
+                            if key.code == KeyCode::Char('c') && key.modifiers.contains(event::KeyModifiers::CONTROL) {
+                                tx.send(AppAction::SigInt).await.ok();
+                            } else {
+                                match key.code {
+                                    KeyCode::Esc => {
+                                        tx.send(AppAction::InputEscape).await.ok();
                                     }
+                                    KeyCode::Enter => {
+                                        tx.send(AppAction::InputSubmit).await.ok();
+                                    }
+                                    KeyCode::Backspace => {
+                                        tx.send(AppAction::InputBackspace).await.ok();
+                                    }
+                                    KeyCode::Delete => {
+                                        tx.send(AppAction::InputDelete).await.ok();
+                                    }
+                                    KeyCode::Up => {
+                                        tx.send(AppAction::SelectPrevious).await.ok();
+                                    }
+                                    KeyCode::Down => {
+                                        tx.send(AppAction::SelectNext).await.ok();
+                                    }
+                                    KeyCode::Left => {
+                                        tx.send(AppAction::SelectLeft).await.ok();
+                                    }
+                                    KeyCode::Right => {
+                                        tx.send(AppAction::SelectRight).await.ok();
+                                    }
+                                    KeyCode::Char(c) => {
+                                        tx.send(AppAction::InputChar(c)).await.ok();
+                                    }
+                                    _ => {}
                                 }
                             }
                         }
@@ -668,105 +666,97 @@ async fn move_selection(state: &mut MutexGuard<'_, App>, n: i32, total_filtered_
                 state.selection_index = (state.selection_index + n.unsigned_abs() as usize) % 3;
             }
         }
-        AppState::SelectingDM => {
-            if !state.dms.is_empty() {
-                if n < 0 {
-                    state.selection_index = if state.selection_index == 0 {
-                        state.dms.len() - n.unsigned_abs() as usize
-                    } else {
-                        state.selection_index - n.unsigned_abs() as usize
-                    };
+        AppState::SelectingDM if !state.dms.is_empty() => {
+            if n < 0 {
+                state.selection_index = if state.selection_index == 0 {
+                    state.dms.len() - n.unsigned_abs() as usize
                 } else {
-                    state.selection_index =
-                        (state.selection_index + n.unsigned_abs() as usize) % state.dms.len();
-                }
-            }
-        }
-        AppState::SelectingGuild => {
-            if !state.guilds.is_empty() {
-                if n < 0 {
-                    state.selection_index = if state.selection_index == 0 {
-                        state.guilds.len() - n.unsigned_abs() as usize
-                    } else {
-                        state.selection_index - n.unsigned_abs() as usize
-                    };
-                } else {
-                    state.selection_index =
-                        (state.selection_index + n.unsigned_abs() as usize) % state.guilds.len();
-                }
-            }
-        }
-        AppState::SelectingChannel(_) => {
-            if !state.channels.is_empty() {
-                let filter_text = state.search_input.to_lowercase();
-                let permission_context = &state.context;
-
-                let should_display_content = |c: &Channel| {
-                    let is_readable = permission_context
-                        .as_ref()
-                        .is_some_and(|context| c.is_readable(context));
-
-                    is_readable
-                        && (filter_text.is_empty() || c.name.to_lowercase().contains(&filter_text))
+                    state.selection_index - n.unsigned_abs() as usize
                 };
-
-                let len: usize = state
-                    .channels
-                    .iter()
-                    .flat_map(|c| {
-                        if c.channel_type == 4 {
-                            let mut list_items_to_render: Vec<&Channel> = Vec::new();
-
-                            let name_matches = filter_text.is_empty()
-                                || c.name.to_lowercase().contains(&filter_text);
-
-                            let child_matches = c.children.as_ref().is_some_and(|children| {
-                                children.iter().any(should_display_content)
-                            });
-
-                            if name_matches || child_matches {
-                                list_items_to_render.push(c);
-
-                                if let Some(children) = &c.children {
-                                    list_items_to_render.extend(
-                                        children
-                                            .iter()
-                                            .filter(|child| should_display_content(child)),
-                                    );
-                                }
-                            }
-                            list_items_to_render
-                        } else if should_display_content(c) {
-                            vec![c]
-                        } else {
-                            vec![]
-                        }
-                    })
-                    .count();
-
-                if n < 0 {
-                    state.selection_index = if state.selection_index == 0 {
-                        len - n.unsigned_abs() as usize
-                    } else {
-                        state.selection_index - n.unsigned_abs() as usize
-                    };
-                } else {
-                    state.selection_index =
-                        (state.selection_index + n.unsigned_abs() as usize) % len;
-                }
+            } else {
+                state.selection_index =
+                    (state.selection_index + n.unsigned_abs() as usize) % state.dms.len();
             }
         }
-        AppState::EmojiSelection(_) => {
-            if total_filtered_emojis > 0 {
-                if n < 0 {
-                    state.emoji_index = if state.emoji_index == 0 {
-                        total_filtered_emojis - 1
-                    } else {
-                        state.emoji_index - 1
-                    };
+        AppState::SelectingGuild if !state.guilds.is_empty() => {
+            if n < 0 {
+                state.selection_index = if state.selection_index == 0 {
+                    state.guilds.len() - n.unsigned_abs() as usize
                 } else {
-                    state.emoji_index = (state.emoji_index + 1) % total_filtered_emojis;
-                }
+                    state.selection_index - n.unsigned_abs() as usize
+                };
+            } else {
+                state.selection_index =
+                    (state.selection_index + n.unsigned_abs() as usize) % state.guilds.len();
+            }
+        }
+        AppState::SelectingChannel(_) if !state.channels.is_empty() => {
+            let filter_text = state.search_input.to_lowercase();
+            let permission_context = &state.context;
+
+            let should_display_content = |c: &Channel| {
+                let is_readable = permission_context
+                    .as_ref()
+                    .is_some_and(|context| c.is_readable(context));
+
+                is_readable
+                    && (filter_text.is_empty() || c.name.to_lowercase().contains(&filter_text))
+            };
+
+            let len: usize = state
+                .channels
+                .iter()
+                .flat_map(|c| {
+                    if c.channel_type == 4 {
+                        let mut list_items_to_render: Vec<&Channel> = Vec::new();
+
+                        let name_matches = filter_text.is_empty()
+                            || c.name.to_lowercase().contains(&filter_text);
+
+                        let child_matches = c.children.as_ref().is_some_and(|children| {
+                            children.iter().any(should_display_content)
+                        });
+
+                        if name_matches || child_matches {
+                            list_items_to_render.push(c);
+
+                            if let Some(children) = &c.children {
+                                list_items_to_render.extend(
+                                    children
+                                        .iter()
+                                        .filter(|child| should_display_content(child)),
+                                );
+                            }
+                        }
+                        list_items_to_render
+                    } else if should_display_content(c) {
+                        vec![c]
+                    } else {
+                        vec![]
+                    }
+                })
+                .count();
+
+            if n < 0 {
+                state.selection_index = if state.selection_index == 0 {
+                    len - n.unsigned_abs() as usize
+                } else {
+                    state.selection_index - n.unsigned_abs() as usize
+                };
+            } else {
+                state.selection_index =
+                    (state.selection_index + n.unsigned_abs() as usize) % len;
+            }
+        }
+        AppState::EmojiSelection(_) if total_filtered_emojis > 0 => {
+            if n < 0 {
+                state.emoji_index = if state.emoji_index == 0 {
+                    total_filtered_emojis - 1
+                } else {
+                    state.emoji_index - 1
+                };
+            } else {
+                state.emoji_index = (state.emoji_index + 1) % total_filtered_emojis;
             }
         }
         _ => {}

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -819,11 +819,15 @@ pub async fn handle_keys_events(
         AppAction::InputEscape => {
             // In vim mode, Esc switches from Insert to Normal mode and returns early.
             // In non-vim mode (or vim Normal mode), Esc triggers navigation (handled below).
-            if state.vim_mode && state.mode == InputMode::Insert
+            if state.vim_mode && (state.mode == InputMode::Insert
                 || state.mode == InputMode::Command
                 || state.mode == InputMode::Search
+                || state.mode == InputMode::Visual)
             {
                 state.mode = InputMode::Normal;
+                if let Some(vim_state) = &mut state.vim_state {
+                    vim_state.visual_start = None;
+                }
                 if state.mode == InputMode::Command || state.mode == InputMode::Search {
                     state.input = state.saved_input.clone().unwrap_or_default();
                     state.saved_input = None;
@@ -948,7 +952,7 @@ pub async fn handle_keys_events(
                 handle_user_typing(&mut state);
             } else {
                 match state.mode {
-                    InputMode::Normal => {
+                    InputMode::Normal | InputMode::Visual => {
                         vim::handle_vim_keys(state, c, tx_action).await;
                     }
                     InputMode::Insert | InputMode::Command | InputMode::Search => {

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -710,12 +710,13 @@ async fn move_selection(state: &mut MutexGuard<'_, App>, n: i32, total_filtered_
                     if c.channel_type == 4 {
                         let mut list_items_to_render: Vec<&Channel> = Vec::new();
 
-                        let name_matches = filter_text.is_empty()
-                            || c.name.to_lowercase().contains(&filter_text);
+                        let name_matches =
+                            filter_text.is_empty() || c.name.to_lowercase().contains(&filter_text);
 
-                        let child_matches = c.children.as_ref().is_some_and(|children| {
-                            children.iter().any(should_display_content)
-                        });
+                        let child_matches = c
+                            .children
+                            .as_ref()
+                            .is_some_and(|children| children.iter().any(should_display_content));
 
                         if name_matches || child_matches {
                             list_items_to_render.push(c);
@@ -744,8 +745,7 @@ async fn move_selection(state: &mut MutexGuard<'_, App>, n: i32, total_filtered_
                     state.selection_index - n.unsigned_abs() as usize
                 };
             } else {
-                state.selection_index =
-                    (state.selection_index + n.unsigned_abs() as usize) % len;
+                state.selection_index = (state.selection_index + n.unsigned_abs() as usize) % len;
             }
         }
         AppState::EmojiSelection(_) if total_filtered_emojis > 0 => {

--- a/src/ui/vim.rs
+++ b/src/ui/vim.rs
@@ -605,16 +605,28 @@ pub async fn handle_vim_keys(
                 if let Some(vs) = visual_start {
                     let mut start = vs.min(state.cursor_position);
                     let mut end = vs.max(state.cursor_position);
-                    let end_len = state.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
+                    let end_len = state.input[end..]
+                        .chars()
+                        .next()
+                        .map(|c| c.len_utf8())
+                        .unwrap_or(0);
                     end = (end + end_len).min(state.input.len());
                     if state.mode == InputMode::VisualLine {
                         start = state.input[..start].rfind('\n').map(|i| i + 1).unwrap_or(0);
-                        end = state.input[end..].find('\n').map(|i| end + i + 1).unwrap_or(state.input.len());
+                        end = state.input[end..]
+                            .find('\n')
+                            .map(|i| end + i + 1)
+                            .unwrap_or(state.input.len());
                     }
                     if start < end {
                         let deleted: String = state.input.drain(start..end).collect();
+                        let is_linewise = state.mode == InputMode::VisualLine;
                         if let Some(vim_state) = &mut state.vim_state {
-                            vim_state.yank_buffer = deleted;
+                            if is_linewise {
+                                vim_state.yank_buffer = format!("\n{}", deleted.trim_matches('\n'));
+                            } else {
+                                vim_state.yank_buffer = deleted;
+                            }
                         }
                         state.cursor_position = start;
                     }
@@ -676,14 +688,14 @@ pub async fn handle_vim_keys(
                         .drain(current_line_start..next_newline_index + 1)
                         .collect();
                     if let Some(vim_state) = &mut state.vim_state {
-                        vim_state.yank_buffer = deleted;
+                        vim_state.yank_buffer = format!("\n{}", deleted.trim_matches('\n'));
                     }
                     state.cursor_position = current_line_start;
                 } else if current_line_start > 0 {
                     let len = state.input.len();
                     let deleted: String = state.input.drain(current_line_start - 1..len).collect();
                     if let Some(vim_state) = &mut state.vim_state {
-                        vim_state.yank_buffer = deleted;
+                        vim_state.yank_buffer = format!("\n{}", deleted.trim_matches('\n'));
                     }
                     let prev_line_start = state.input[..current_line_start - 1]
                         .rfind('\n')
@@ -694,7 +706,7 @@ pub async fn handle_vim_keys(
                     let deleted = state.input.clone();
                     state.input.clear();
                     if let Some(vim_state) = &mut state.vim_state {
-                        vim_state.yank_buffer = deleted;
+                        vim_state.yank_buffer = format!("\n{}", deleted.trim_matches('\n'));
                     }
                     state.cursor_position = 0;
                 }
@@ -744,16 +756,28 @@ pub async fn handle_vim_keys(
                 if let Some(vs) = visual_start {
                     let mut start = vs.min(state.cursor_position);
                     let mut end = vs.max(state.cursor_position);
-                    let end_len = state.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
+                    let end_len = state.input[end..]
+                        .chars()
+                        .next()
+                        .map(|c| c.len_utf8())
+                        .unwrap_or(0);
                     end = (end + end_len).min(state.input.len());
                     if state.mode == InputMode::VisualLine {
                         start = state.input[..start].rfind('\n').map(|i| i + 1).unwrap_or(0);
-                        end = state.input[end..].find('\n').map(|i| end + i + 1).unwrap_or(state.input.len());
+                        end = state.input[end..]
+                            .find('\n')
+                            .map(|i| end + i + 1)
+                            .unwrap_or(state.input.len());
                     }
                     if start < end {
                         let deleted: String = state.input.drain(start..end).collect();
+                        let is_linewise = state.mode == InputMode::VisualLine;
                         if let Some(vim_state) = &mut state.vim_state {
-                            vim_state.yank_buffer = deleted;
+                            if is_linewise {
+                                vim_state.yank_buffer = format!("\n{}", deleted.trim_matches('\n'));
+                            } else {
+                                vim_state.yank_buffer = deleted;
+                            }
                         }
                         state.cursor_position = start;
                     }
@@ -790,16 +814,28 @@ pub async fn handle_vim_keys(
                 if let Some(vs) = visual_start {
                     let mut start = vs.min(state.cursor_position);
                     let mut end = vs.max(state.cursor_position);
-                    let end_len = state.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
+                    let end_len = state.input[end..]
+                        .chars()
+                        .next()
+                        .map(|c| c.len_utf8())
+                        .unwrap_or(0);
                     end = (end + end_len).min(state.input.len());
                     if state.mode == InputMode::VisualLine {
                         start = state.input[..start].rfind('\n').map(|i| i + 1).unwrap_or(0);
-                        end = state.input[end..].find('\n').map(|i| end + i + 1).unwrap_or(state.input.len());
+                        end = state.input[end..]
+                            .find('\n')
+                            .map(|i| end + i + 1)
+                            .unwrap_or(state.input.len());
                     }
                     if start < end {
                         let yanked = state.input[start..end].to_string();
+                        let is_linewise = state.mode == InputMode::VisualLine;
                         if let Some(vim_state) = &mut state.vim_state {
-                            vim_state.yank_buffer = yanked;
+                            if is_linewise {
+                                vim_state.yank_buffer = format!("\n{}", yanked.trim_matches('\n'));
+                            } else {
+                                vim_state.yank_buffer = yanked;
+                            }
                         }
                     }
                 }
@@ -815,15 +851,15 @@ pub async fn handle_vim_keys(
                         .rfind('\n')
                         .map(|i| i + 1)
                         .unwrap_or(0);
-                    
+
                     let next_newline_index = state.input[current_pos..]
                         .find('\n')
                         .map(|i| current_pos + i)
                         .unwrap_or(state.input.len());
-                        
+
                     let yanked = state.input[current_line_start..next_newline_index].to_string();
                     if let Some(vim_state) = &mut state.vim_state {
-                        vim_state.yank_buffer = yanked;
+                        vim_state.yank_buffer = format!("\n{}", yanked.trim_matches('\n'));
                         vim_state.operator = None;
                     }
                 } else if let Some(vim_state) = &mut state.vim_state {
@@ -842,13 +878,30 @@ pub async fn handle_vim_keys(
                 let yanked = vim_state.yank_buffer.clone();
                 if !yanked.is_empty() {
                     let mut pos = state.cursor_position;
-                    if pos < state.input.len() {
-                        let char_len = state.input[pos..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
-                        pos += char_len;
+                    if yanked.starts_with('\n') {
+                        pos = state.input[pos..]
+                            .find('\n')
+                            .map(|i| pos + i)
+                            .unwrap_or(state.input.len());
+                        state.input.insert_str(pos, &yanked);
+                        state.cursor_position = pos + 1;
+                    } else {
+                        if pos < state.input.len() {
+                            let char_len = state.input[pos..]
+                                .chars()
+                                .next()
+                                .map(|c| c.len_utf8())
+                                .unwrap_or(0);
+                            pos += char_len;
+                        }
+                        state.input.insert_str(pos, &yanked);
+                        let last_char_len = yanked
+                            .chars()
+                            .next_back()
+                            .map(|c| c.len_utf8())
+                            .unwrap_or(0);
+                        state.cursor_position = pos + yanked.len() - last_char_len;
                     }
-                    state.input.insert_str(pos, &yanked);
-                    let last_char_len = yanked.chars().next_back().map(|c| c.len_utf8()).unwrap_or(0);
-                    state.cursor_position = pos + yanked.len() - last_char_len;
                     clamp_cursor(&mut state);
                 }
             }
@@ -862,10 +915,21 @@ pub async fn handle_vim_keys(
             if let Some(vim_state) = &state.vim_state {
                 let yanked = vim_state.yank_buffer.clone();
                 if !yanked.is_empty() {
-                    let pos = state.cursor_position;
-                    state.input.insert_str(pos, &yanked);
-                    let last_char_len = yanked.chars().next_back().map(|c| c.len_utf8()).unwrap_or(0);
-                    state.cursor_position = pos + yanked.len() - last_char_len;
+                    let mut pos = state.cursor_position;
+                    if yanked.starts_with('\n') {
+                        pos = state.input[..pos].rfind('\n').map(|i| i + 1).unwrap_or(0);
+                        let to_insert = format!("{}\n", &yanked[1..]);
+                        state.input.insert_str(pos, &to_insert);
+                        state.cursor_position = pos;
+                    } else {
+                        state.input.insert_str(pos, &yanked);
+                        let last_char_len = yanked
+                            .chars()
+                            .next_back()
+                            .map(|c| c.len_utf8())
+                            .unwrap_or(0);
+                        state.cursor_position = pos + yanked.len() - last_char_len;
+                    }
                     clamp_cursor(&mut state);
                 }
             }

--- a/src/ui/vim.rs
+++ b/src/ui/vim.rs
@@ -916,9 +916,9 @@ pub async fn handle_vim_keys(
                 let yanked = vim_state.yank_buffer.clone();
                 if !yanked.is_empty() {
                     let mut pos = state.cursor_position;
-                    if yanked.starts_with('\n') {
+                    if let Some(stripped) = yanked.strip_prefix('\n') {
                         pos = state.input[..pos].rfind('\n').map(|i| i + 1).unwrap_or(0);
-                        let to_insert = format!("{}\n", &yanked[1..]);
+                        let to_insert = format!("{}\n", stripped);
                         state.input.insert_str(pos, &to_insert);
                         state.cursor_position = pos;
                     } else {

--- a/src/ui/vim.rs
+++ b/src/ui/vim.rs
@@ -33,6 +33,7 @@ pub struct VimState {
     pub pending_keys: String,
     pub last_action_time: Instant,
     pub visual_start: Option<usize>,
+    pub yank_buffer: String,
 }
 
 impl Default for VimState {
@@ -42,6 +43,7 @@ impl Default for VimState {
             pending_keys: String::new(),
             last_action_time: Instant::now(),
             visual_start: None,
+            yank_buffer: String::new(),
         }
     }
 }
@@ -213,6 +215,10 @@ fn execute_operator(state: &mut MutexGuard<'_, App>, operator: VimOperator, rang
         VimOperator::Delete => {
             if high > low && state.input.is_char_boundary(low) && state.input.is_char_boundary(high)
             {
+                let deleted = state.input[low..high].to_string();
+                if let Some(vim_state) = &mut state.vim_state {
+                    vim_state.yank_buffer = deleted;
+                }
                 state.input.drain(low..high);
                 state.cursor_position = low;
             }
@@ -602,7 +608,10 @@ pub async fn handle_vim_keys(
                     let end_len = state.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
                     let end = (end + end_len).min(state.input.len());
                     if start < end {
-                        state.input.drain(start..end);
+                        let deleted: String = state.input.drain(start..end).collect();
+                        if let Some(vim_state) = &mut state.vim_state {
+                            vim_state.yank_buffer = deleted;
+                        }
                         state.cursor_position = start;
                     }
                 }
@@ -658,20 +667,31 @@ pub async fn handle_vim_keys(
 
                 if let Some(newline_offset) = state.input[current_pos..].find('\n') {
                     let next_newline_index = current_pos + newline_offset;
-                    state
+                    let deleted: String = state
                         .input
-                        .drain(current_line_start..next_newline_index + 1);
+                        .drain(current_line_start..next_newline_index + 1)
+                        .collect();
+                    if let Some(vim_state) = &mut state.vim_state {
+                        vim_state.yank_buffer = deleted;
+                    }
                     state.cursor_position = current_line_start;
                 } else if current_line_start > 0 {
                     let len = state.input.len();
-                    state.input.drain(current_line_start - 1..len);
+                    let deleted: String = state.input.drain(current_line_start - 1..len).collect();
+                    if let Some(vim_state) = &mut state.vim_state {
+                        vim_state.yank_buffer = deleted;
+                    }
                     let prev_line_start = state.input[..current_line_start - 1]
                         .rfind('\n')
                         .map(|i| i + 1)
                         .unwrap_or(0);
                     state.cursor_position = prev_line_start;
                 } else {
+                    let deleted = state.input.clone();
                     state.input.clear();
+                    if let Some(vim_state) = &mut state.vim_state {
+                        vim_state.yank_buffer = deleted;
+                    }
                     state.cursor_position = 0;
                 }
 
@@ -709,7 +729,10 @@ pub async fn handle_vim_keys(
                     let end_len = state.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
                     let end = (end + end_len).min(state.input.len());
                     if start < end {
-                        state.input.drain(start..end);
+                        let deleted: String = state.input.drain(start..end).collect();
+                        if let Some(vim_state) = &mut state.vim_state {
+                            vim_state.yank_buffer = deleted;
+                        }
                         state.cursor_position = start;
                     }
                 }
@@ -732,8 +755,93 @@ pub async fn handle_vim_keys(
                 && let Some(ch) = state.input[pos..].chars().next()
             {
                 let char_end = pos + ch.len_utf8();
-                state.input.drain(pos..char_end);
+                let deleted: String = state.input.drain(pos..char_end).collect();
+                if let Some(vim_state) = &mut state.vim_state {
+                    vim_state.yank_buffer = deleted;
+                }
                 clamp_cursor(&mut state);
+            }
+        }
+        'y' => {
+            if state.mode == InputMode::Visual {
+                let visual_start = state.vim_state.as_ref().and_then(|vs| vs.visual_start);
+                if let Some(vs) = visual_start {
+                    let start = vs.min(state.cursor_position);
+                    let end = vs.max(state.cursor_position);
+                    let end_len = state.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
+                    let end = (end + end_len).min(state.input.len());
+                    if start < end {
+                        let yanked = state.input[start..end].to_string();
+                        if let Some(vim_state) = &mut state.vim_state {
+                            vim_state.yank_buffer = yanked;
+                        }
+                    }
+                }
+                if let Some(vim_state) = &mut state.vim_state {
+                    vim_state.visual_start = None;
+                }
+                state.mode = InputMode::Normal;
+                clamp_cursor(&mut state);
+            } else {
+                if let Some(VimOperator::_Yank) = current_operator {
+                    let current_pos = state.cursor_position;
+                    let current_line_start = state.input[..current_pos]
+                        .rfind('\n')
+                        .map(|i| i + 1)
+                        .unwrap_or(0);
+                    
+                    let next_newline_index = state.input[current_pos..]
+                        .find('\n')
+                        .map(|i| current_pos + i)
+                        .unwrap_or(state.input.len());
+                        
+                    let yanked = state.input[current_line_start..next_newline_index].to_string();
+                    if let Some(vim_state) = &mut state.vim_state {
+                        vim_state.yank_buffer = yanked;
+                        vim_state.operator = None;
+                    }
+                } else if let Some(vim_state) = &mut state.vim_state {
+                    vim_state.operator = Some(VimOperator::_Yank);
+                    vim_state.last_action_time = Instant::now();
+                }
+            }
+        }
+        'p' => {
+            if let AppState::Chatting(_) = &state.state
+                && state.selection_index > 0
+            {
+                return;
+            }
+            if let Some(vim_state) = &state.vim_state {
+                let yanked = vim_state.yank_buffer.clone();
+                if !yanked.is_empty() {
+                    let mut pos = state.cursor_position;
+                    if pos < state.input.len() {
+                        let char_len = state.input[pos..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
+                        pos += char_len;
+                    }
+                    state.input.insert_str(pos, &yanked);
+                    let last_char_len = yanked.chars().next_back().map(|c| c.len_utf8()).unwrap_or(0);
+                    state.cursor_position = pos + yanked.len() - last_char_len;
+                    clamp_cursor(&mut state);
+                }
+            }
+        }
+        'P' => {
+            if let AppState::Chatting(_) = &state.state
+                && state.selection_index > 0
+            {
+                return;
+            }
+            if let Some(vim_state) = &state.vim_state {
+                let yanked = vim_state.yank_buffer.clone();
+                if !yanked.is_empty() {
+                    let pos = state.cursor_position;
+                    state.input.insert_str(pos, &yanked);
+                    let last_char_len = yanked.chars().next_back().map(|c| c.len_utf8()).unwrap_or(0);
+                    state.cursor_position = pos + yanked.len() - last_char_len;
+                    clamp_cursor(&mut state);
+                }
             }
         }
         'g' => {

--- a/src/ui/vim.rs
+++ b/src/ui/vim.rs
@@ -32,6 +32,7 @@ pub struct VimState {
     pub operator: Option<VimOperator>,
     pub pending_keys: String,
     pub last_action_time: Instant,
+    pub visual_start: Option<usize>,
 }
 
 impl Default for VimState {
@@ -40,6 +41,7 @@ impl Default for VimState {
             operator: None,
             pending_keys: String::new(),
             last_action_time: Instant::now(),
+            visual_start: None,
         }
     }
 }
@@ -592,6 +594,26 @@ pub async fn handle_vim_keys(
             }
         }
         'd' => {
+            if state.mode == InputMode::Visual {
+                let visual_start = state.vim_state.as_ref().and_then(|vs| vs.visual_start);
+                if let Some(vs) = visual_start {
+                    let start = vs.min(state.cursor_position);
+                    let end = vs.max(state.cursor_position);
+                    let end_len = state.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
+                    let end = (end + end_len).min(state.input.len());
+                    if start < end {
+                        state.input.drain(start..end);
+                        state.cursor_position = start;
+                    }
+                }
+                if let Some(vim_state) = &mut state.vim_state {
+                    vim_state.visual_start = None;
+                }
+                state.mode = InputMode::Normal;
+                clamp_cursor(&mut state);
+                return;
+            }
+
             if let AppState::Chatting(channel) = &state.state
                 && state.selection_index > 0
             {
@@ -664,7 +686,41 @@ pub async fn handle_vim_keys(
             }
         }
 
+        'v' => {
+            if state.mode == InputMode::Normal {
+                state.mode = InputMode::Visual;
+                let cp = state.cursor_position;
+                if let Some(vim_state) = &mut state.vim_state {
+                    vim_state.visual_start = Some(cp);
+                }
+            } else if state.mode == InputMode::Visual {
+                state.mode = InputMode::Normal;
+                if let Some(vim_state) = &mut state.vim_state {
+                    vim_state.visual_start = None;
+                }
+            }
+        }
         'x' => {
+            if state.mode == InputMode::Visual {
+                let visual_start = state.vim_state.as_ref().and_then(|vs| vs.visual_start);
+                if let Some(vs) = visual_start {
+                    let start = vs.min(state.cursor_position);
+                    let end = vs.max(state.cursor_position);
+                    let end_len = state.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
+                    let end = (end + end_len).min(state.input.len());
+                    if start < end {
+                        state.input.drain(start..end);
+                        state.cursor_position = start;
+                    }
+                }
+                if let Some(vim_state) = &mut state.vim_state {
+                    vim_state.visual_start = None;
+                }
+                state.mode = InputMode::Normal;
+                clamp_cursor(&mut state);
+                return;
+            }
+
             if let AppState::Chatting(_) = &state.state
                 && state.selection_index > 0
             {

--- a/src/ui/vim.rs
+++ b/src/ui/vim.rs
@@ -600,13 +600,17 @@ pub async fn handle_vim_keys(
             }
         }
         'd' => {
-            if state.mode == InputMode::Visual {
+            if state.mode == InputMode::Visual || state.mode == InputMode::VisualLine {
                 let visual_start = state.vim_state.as_ref().and_then(|vs| vs.visual_start);
                 if let Some(vs) = visual_start {
-                    let start = vs.min(state.cursor_position);
-                    let end = vs.max(state.cursor_position);
+                    let mut start = vs.min(state.cursor_position);
+                    let mut end = vs.max(state.cursor_position);
                     let end_len = state.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
-                    let end = (end + end_len).min(state.input.len());
+                    end = (end + end_len).min(state.input.len());
+                    if state.mode == InputMode::VisualLine {
+                        start = state.input[..start].rfind('\n').map(|i| i + 1).unwrap_or(0);
+                        end = state.input[end..].find('\n').map(|i| end + i + 1).unwrap_or(state.input.len());
+                    }
                     if start < end {
                         let deleted: String = state.input.drain(start..end).collect();
                         if let Some(vim_state) = &mut state.vim_state {
@@ -720,14 +724,32 @@ pub async fn handle_vim_keys(
                 }
             }
         }
+        'V' => {
+            if state.mode == InputMode::Normal {
+                state.mode = InputMode::VisualLine;
+                let cp = state.cursor_position;
+                if let Some(vim_state) = &mut state.vim_state {
+                    vim_state.visual_start = Some(cp);
+                }
+            } else if state.mode == InputMode::VisualLine {
+                state.mode = InputMode::Normal;
+                if let Some(vim_state) = &mut state.vim_state {
+                    vim_state.visual_start = None;
+                }
+            }
+        }
         'x' => {
-            if state.mode == InputMode::Visual {
+            if state.mode == InputMode::Visual || state.mode == InputMode::VisualLine {
                 let visual_start = state.vim_state.as_ref().and_then(|vs| vs.visual_start);
                 if let Some(vs) = visual_start {
-                    let start = vs.min(state.cursor_position);
-                    let end = vs.max(state.cursor_position);
+                    let mut start = vs.min(state.cursor_position);
+                    let mut end = vs.max(state.cursor_position);
                     let end_len = state.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
-                    let end = (end + end_len).min(state.input.len());
+                    end = (end + end_len).min(state.input.len());
+                    if state.mode == InputMode::VisualLine {
+                        start = state.input[..start].rfind('\n').map(|i| i + 1).unwrap_or(0);
+                        end = state.input[end..].find('\n').map(|i| end + i + 1).unwrap_or(state.input.len());
+                    }
                     if start < end {
                         let deleted: String = state.input.drain(start..end).collect();
                         if let Some(vim_state) = &mut state.vim_state {
@@ -763,13 +785,17 @@ pub async fn handle_vim_keys(
             }
         }
         'y' => {
-            if state.mode == InputMode::Visual {
+            if state.mode == InputMode::Visual || state.mode == InputMode::VisualLine {
                 let visual_start = state.vim_state.as_ref().and_then(|vs| vs.visual_start);
                 if let Some(vs) = visual_start {
-                    let start = vs.min(state.cursor_position);
-                    let end = vs.max(state.cursor_position);
+                    let mut start = vs.min(state.cursor_position);
+                    let mut end = vs.max(state.cursor_position);
                     let end_len = state.input[end..].chars().next().map(|c| c.len_utf8()).unwrap_or(0);
-                    let end = (end + end_len).min(state.input.len());
+                    end = (end + end_len).min(state.input.len());
+                    if state.mode == InputMode::VisualLine {
+                        start = state.input[..start].rfind('\n').map(|i| i + 1).unwrap_or(0);
+                        end = state.input[end..].find('\n').map(|i| end + i + 1).unwrap_or(state.input.len());
+                    }
                     if start < end {
                         let yanked = state.input[start..end].to_string();
                         if let Some(vim_state) = &mut state.vim_state {


### PR DESCRIPTION
This pull request adds comprehensive Vim-style visual selection and yank/paste support to the text input area, significantly enhancing keyboard-based text manipulation. It introduces Visual and Visual Line modes, enables yanking (copying) and pasting text or lines, and updates the UI to visually highlight selections. The changes also clean up and refactor selection logic and improve key event handling for maintainability.

**Vim Visual Mode and Yank/Paste Functionality:**

* Added `Visual` and `VisualLine` modes to `InputMode`, supporting character-wise and line-wise visual selections (`src/main.rs`, `src/ui/vim.rs`). [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR132-R133) [[2]](diffhunk://#diff-4286eef8792a55c247ba966dd336882e308e10b9be51c6237cf42edc6d47f21fR35-R36) [[3]](diffhunk://#diff-4286eef8792a55c247ba966dd336882e308e10b9be51c6237cf42edc6d47f21fR45-R46)
* Implemented visual selection logic, including tracking the start of a selection, updating the UI to highlight selected text, and handling Esc to exit visual mode and clear selection (`src/ui/draw.rs`, `src/ui/events.rs`, `src/ui/vim.rs`). [[1]](diffhunk://#diff-a2fbf6328d055614aa98ae952cbd53e5b792058436c91086154750aa2c1f085cR927-R988) [[2]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L822-R822) [[3]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L951-R947) [[4]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L80-R80) [[5]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L117)
* Added yank buffer to `VimState` and logic for yanking (copying) and pasting selected text or lines, including support for `y`, `yy`, `p`, and `P` keybinds (`src/ui/vim.rs`). [[1]](diffhunk://#diff-4286eef8792a55c247ba966dd336882e308e10b9be51c6237cf42edc6d47f21fR35-R36) [[2]](diffhunk://#diff-4286eef8792a55c247ba966dd336882e308e10b9be51c6237cf42edc6d47f21fR45-R46) [[3]](diffhunk://#diff-4286eef8792a55c247ba966dd336882e308e10b9be51c6237cf42edc6d47f21fR218-R221) [[4]](diffhunk://#diff-4286eef8792a55c247ba966dd336882e308e10b9be51c6237cf42edc6d47f21fR603-R641) [[5]](diffhunk://#diff-4286eef8792a55c247ba966dd336882e308e10b9be51c6237cf42edc6d47f21fL639-R710) [[6]](diffhunk://#diff-4286eef8792a55c247ba966dd336882e308e10b9be51c6237cf42edc6d47f21fR725-R792)

**Keybindings and User Documentation:**

* Updated Vim keybindings documentation to include visual selection, yanking, and pasting commands (`readme/keybinds.md`).

**Selection and Key Event Refactors:**

* Refactored selection logic for DMs, guilds, channels, and emojis to use pattern matching for clarity and maintainability (`src/ui/events.rs`). [[1]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L671-R669) [[2]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L684-R681) [[3]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L698-R693) [[4]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L720-R719) [[5]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L754-R751) [[6]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L771)
* Improved key event handling by simplifying match arms and removing redundant code (`src/ui/events.rs`). [[1]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L80-R80) [[2]](diffhunk://#diff-c12607e427197591be60b4e46ca30633f3459e5a28677ffc7fa8cf223fa15dd7L117)

**Other:**

* Added a new file with two lines of text (`file`).